### PR TITLE
Integrate Tommie's excellent annotated bibliography

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,7 @@
 <footer>
   <a href="/">Home</a>
   | <a href="/about">About</a>
+  | <a href="/resources">Resources</a>
   | <a href="/contact">Contact</a>
   <div class="iblock">
     Published {{ page.date | date: '%d %b %Y' }}

--- a/_includes/htmlhead.html
+++ b/_includes/htmlhead.html
@@ -1,0 +1,9 @@
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="x-ua-compatible" content="ie=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
+  <link rel="stylesheet" href="{{ "/css/tufte.css" | prepend: site.baseurl }}" />
+  <link rel="stylesheet" href="{{ "/css/mdecl.css" | prepend: site.baseurl }}" />
+  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}" />
+</head> 

--- a/_layouts/htmlpage.html
+++ b/_layouts/htmlpage.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+{% include htmlhead.html %}
+<body>
+  <main>
+    {% include header.html %}
+    <article>
+      {{ content }}
+    </article>
+  </main>
+  {% include footer.html %}
+</body>
+
+</html>

--- a/_layouts/rawpage.html
+++ b/_layouts/rawpage.html
@@ -1,0 +1,4 @@
+---
+layout: htmlpage
+---
+{{ content }}

--- a/_pages/04_resources.md
+++ b/_pages/04_resources.md
@@ -1,0 +1,9 @@
+---
+layout: page
+title: Resources
+permalink: /resources
+date: 2018-09-18
+---
+
+* An [annotated bibliography](bibliography)
+

--- a/_pages/DeclarativeMarkupDocs.html
+++ b/_pages/DeclarativeMarkupDocs.html
@@ -1,0 +1,564 @@
+---
+layout: rawpage
+title: Declarative Markup&#x3a An Annotated Bibliography
+permalink: /resources/bibliography
+date: 2018-09-18
+---
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Declarative Markup: An Annotated Bibliography</title>
+  <meta charset="utf-8" />
+  <meta name="date" content="2018-09-17" />
+  <meta name="title" content="Declarative Markup: An Annotated Bibliography"/>
+  <meta name="description"
+        content="A list of resources about and related to declarative markup" />
+  <meta name="keywords"
+        content="declarative markup, generic markup, descriptive markup, XML, SGML"/>
+  <style type="text/css">
+    .annotation
+    {
+        margin-left: 25px;
+        background: #E8E8E8;
+        padding: 5px;
+        max-height: 50px;
+        overflow-y: scroll;
+    }
+
+    .annotation p
+    {
+        margin-top: 0;
+    }
+
+    .annotation:hover
+    {
+        margin-left: 25px;
+        background: #E8E8E8;
+        padding: 5px;
+        max-height: 600px;
+        overflow-y: scroll;
+    }
+
+    .annotation:hover p
+    {
+        margin-top: 1em;
+    }
+
+    .annotation:focus
+    {
+        margin-left: 25px;
+        background: #E8E8E8;
+        padding: 5px;
+        max-height: 600px;
+        overflow-y: scroll;
+     }
+
+    .annotation:focus p
+    {
+        margin-top: 1em;
+    }
+
+    .ref-location
+    {
+        margin-left: 25px;
+        border-left: 1px;
+        margin-top: 0px
+    }
+
+    section
+    {
+        margin-left: 25px;
+    }
+
+    section h1
+    {
+        border-top: 2px solid #aaaaaa;
+        padding-top: 0.5em;
+        margin-left: -25px;
+    }
+
+    .sig
+    {
+        text-align: right;
+    }
+
+    .toc
+    {
+    }
+
+    .toc h3
+    {
+        margin-bottom: 0.5em;
+    }
+
+    .toc ul
+    {
+        margin-top: 0;
+    }
+    </style>
+</head>
+<body>
+  <p>This list of works about declarative markup is, as all such lists
+  must be, incomplete and based on the opinions of the contributors.
+  The intent is to make available the widely scattered literature on
+  the philosophy of markup that has been variously called “generic
+  markup”, “descriptive markup”, and “declarative markup”. Works that
+  have sections that are about declarative markup are within scope for
+  this list, especially if annotated to point to the portion of the
+  document that is <b>about</b> declarative markup per se. Works that
+  are about particular declarative markup languages, declarative
+  programming, XML, CSS, or any of hundreds of related concepts but
+  that do not directly address <strong>declarative markup</strong>
+  should be in the “Related Concepts” appendix of this bibliography,
+  not in the body of the document.</p>
+
+  <p>Annotations on this list are used to describe the work, point to
+  portions of a work that are particularly relevant to declarative
+  markkup, and provide the annotator's opinion on the work. All
+  annotations should be signed by the annotator. We ask that if you
+  disagree with an annotation you write an additional annotation with
+  your point of view; do not edit, remove, or replace some else's
+  annotation. </p>
+
+  <aside class="toc">
+    <h3>Table of Contents</h3>
+    <ul>
+      <li><a href="#declmarkup">About Declarative Markup <i>per se</i></a></li>
+      <li><a href="#markupuses">Declarative Markup Uses</a></li>
+      <li><a href="#related">Related Concepts</a></li>
+    </ul>
+  </aside>
+
+  <section id="declmarkup">
+    <h1>About Declarative Markup <i>per se</i></h1>
+
+    <div class="bib-entry">
+      <h2 class="sort-name">Clark</h2>
+      <h3 class="ref-title">“Content Management and the Separation of Presentation and Content.” by David P. Clark</h3>
+      <p class="ref-location">
+        Clark, David P. "Content Management and
+        the Separation of Presentation and Content." Technical
+        Communication Quarterly 17.1. (2008): 35-60.
+        <a href="https://www.tandfonline.com/doi/abs/10.1080/10572250701588624">https://www.tandfonline.com/doi/abs/10.1080/10572250701588624</a>
+      </p>
+
+      <div class="annotation">
+        <p>The importance of separating presentation from content is
+        taken as a given in many kinds of publishing, despite the fact
+        that the notion of separation has received little critical
+        scrutiny. I provide a closer look at the separation, first by
+        providing contemporary and historical context, then by laying
+        out key distinctions in the ways the separation argument is
+        used in Web design versus Web content management versus
+        full-featured content management systems (CMSs). I suggest
+        that these distinctions are critical in how we should view the
+        separation and the implications of the separation for the work
+        of technical communicators.</p>
+        <p class="sig">annotation source: publisher's abstract </p>
+      </div>
+    </div>
+
+    <div class="bib-entry">
+      <h2 class="sort-name">Fennell</h2>
+      <h3 class="ref-title">“Are we losing the declarative Web?” by Philip Fennell</h3>
+      <p class="ref-location">
+        <a href="http://archive.li/q92S5">http://archive.li/q92S5</a>
+      </p>
+      <div class="annotation">
+        <p>“I’m an unashamed fan of the XML stack and because of it, the declarative
+        web too.”</p>
+        <p class="sig">annotation source: quote from the document</p>
+      </div>
+    </div>
+
+    <div class="bib-entry">
+      <h2 class="sort-name">Gennusa</h2>
+      <h3 class="ref-title">“Evolution and use of generic markup languages” by P. L. Gennusa</h3>
+      <p class="ref-location">
+        Gennusa P.L. (1999) Evolution and use of generic markup languages. In: Möhr
+        W., Schmidt I. (eds) SGML und XML. Springer, Berlin, Heidelberg
+        <a href="https://link.springer.com/chapter/10.1007/978-3-642-46881-0_2"
+           >https://link.springer.com/chapter/10.1007/978-3-642-46881-0_2</a>
+      </p>
+      <div class="annotation">
+        <p>A chapter in a book on SGML and XML. Most of the book is in German, this
+        chapter and one other are in English.</p>
+        <p class="sig">annotated by: B. T. Usdin</p>
+      </div>
+    </div>
+
+    <div class="bib-entry">
+      <h2 class="sort-name">Horton</h2>
+      <h3 class="ref-title">“Separate content and presentation” by Sarah Horton</h3>
+      <p class="ref-location">
+        <a href="http://universalusability.com/access_by_design/document_structure/separate.html"
+           >http://universalusability.com/access_by_design/document_structure/separate.html</a>
+      </p>
+      <div class="annotation">
+        <p>“The Web is a medium designed to remove access
+        requirements and to make content accessible to all. ... The
+        key to device independence and universal access is in the
+        separation of content and presentation.”
+        </p>
+        <p class="sig">annotation source: quote from the document</p>
+      </div>
+    </div>
+
+    <div class="bib-entry">
+      <h2 class="sort-name">Kyrnin</h2>
+      <h3 class="ref-title">“Why Use Semantic HTML?” by Jennifer Kyrnin</h3>
+      <p class="ref-location">
+        <a href="https://www.lifewire.com/why-use-semantic-html-3468271"
+           >https://www.lifewire.com/why-use-semantic-html-3468271</a>
+      </p>
+      <div class="annotation">
+        <p>“Creating web documents that have meaning behind the page
+        rendered in a browser is very important. Here are some
+        pointers as to how to understand and write semantic markup.”
+        </p>
+        <p class="sig">annotation source: quote from the document</p>
+      </div>
+    </div>
+
+    <div class="bib-entry">
+      <h2 class="sort-name">Maler</h2>
+      <h3 class="ref-title">“Developing SGML DTDs: From Text to Model to Markup” by Eve Maler and Jeanne El Andaloussi</h3>
+      <p class="ref-location">
+        <a href="http://www.xmlgrrl.com/publications/DSDTD/">http://www.xmlgrrl.com/publications/DSDTD/</a>
+      </p>
+      <div class="annotation">
+        <p>The first, best, and most authoratitive book on design of
+        markup vocabularies. While the examples are all SGML (obsolete
+        for all of us) and the syntax is DTDs (still in use in some
+        communities but clearly not <i>au courant</i>), the point of
+        this book is the logic behind vocabulary design and that is
+        absoultely still current. For the reader interested in
+        declarative markup and too impatient to read the whole book I
+        suggest starting with Section 4.1.2. “Learning to Recognize
+        Semantic Components”.</p>
+        <p>The reader may also be interested in a blog entry in
+        “Pushing String” about this book: <a
+        href="http://www.xmlgrrl.com/blog/publications/developing-sgml-dtds/"
+        >http://www.xmlgrrl.com/blog/publications/developing-sgml-dtds/</a>
+        </p>
+        <p class="sig">annotated by: B. T. Usdin</p>
+      </div>
+    </div>
+
+    <div class="bib-entry">
+      <h2 class="sort-name">Ornbo</h2>
+      <h3 class="ref-title">“The importance of semantic markup” by George Ornbo</h3>
+      <p class="ref-location">
+        <a href="https://shapeshed.com/the-importance-of-semantic-markup/"
+           >https://shapeshed.com/the-importance-of-semantic-markup/</a>
+      </p>
+      <div class="annotation">
+        <p>“Creating web documents that have meaning behind the page
+        rendered in a browser is very important. Here are some
+        pointers as to how to understand and write semantic
+        markup.”</p>
+        <p class="sig">annotation source: quote from the document</p>
+      </div>
+    </div>
+
+    <div class="bib-entry">
+      <h2 class="sort-name">Pemberton</h2>
+      <h3 class="ref-title">“The Power of the Declarative” by Steven Pemberton</h3>
+      <p class="ref-location">
+        <a href="https://www.w3.org/2009/Talks/04-02-steven-declarative/"
+           >https://www.w3.org/2009/Talks/04-02-steven-declarative/</a>
+      </p>
+
+      <div class="annotation">
+        <p>A short slide presentation about declarative markup, emphasizing its
+        power and compactness</p>
+        <p class="sig">annotated by: B. T. Usdin</p>
+      </div>
+    </div>
+
+    <div class="bib-entry">
+      <h2 class="sort-name">Pemberton</h2>
+      <h3 class="ref-title">“The 100 Year Web: In Praise of XML” by Steven Pemberton</h3>
+      <p class="ref-location">
+        Pemberton, Steven. "The 100 Year Web: In Praise of XML." Presented at
+        Balisage: The Markup Conference 2018, Washington, DC, July 31 - August 3, 2018.
+        In Proceedings of Balisage: The Markup
+        Conference 2018. Balisage Series on Markup Technologies, vol.
+        21 (2018).
+        <a href="https://www.balisage.net/Proceedings//vol21/author-pkg/Pemberton01/BalisageVol21-Pemberton01.html">https://doi.org/10.4242/BalisageVol21.Pemberton01.</a>
+      </p>
+    </div>
+
+    <div class="bib-entry">
+      <h2 class="sort-name">Piez</h2>
+      <h3 class="ref-title">“Beyond the ‘descriptive vs. procedural’ distinction” by Wendell Piez</h3>
+      <p class="ref-location">
+        <a href="http://conferences.idealliance.org/extreme/html/2001/Piez01/EML2001Piez01.html"
+           >http://conferences.idealliance.org/extreme/html/2001/Piez01/EML2001Piez01.html</a>
+      </p>
+      <div class="annotation">
+        <p>This 2001 paper has lost the link to its CSS but the content is as
+        relevant now as it ever was. See particularly the section “Generic
+        markup as a form of rhetoric”. </p>
+        <p class="sig">annotated by: B. T. Usdin</p>
+      </div>
+    </div>
+
+    <div class="bib-entry">
+      <h2 class="sort-name">Piez</h2>
+      <h3 class="ref-title">“Format and Content: Should they be separated? Can they
+      be?” by Wendell Piez</h3>
+      <p class="ref-location">
+        <a href="http://conferences.idealliance.org/extreme/html/2005/Piez01/EML2005Piez01.html"
+           >http://conferences.idealliance.org/extreme/html/2005/Piez01/EML2005Piez01.html</a>
+      </p>
+      <div class="annotation">
+        <p>Conventionally, XML design and application methodologies
+        propose that the format in which we create, store and maintain
+        documentary data be isolated from the format of its
+        presentation: this doctrine is usually designated as the
+        "separation of format from content", and the advantages of the
+        layered architecture it implies are often cited as a
+        compelling rationale for XML as a standards-based markup
+        technology. Yet experienced markup designers know that in
+        practice, the separation is often more easily described than
+        achieved, and that this design decision (like any other)
+        involves tradeoffs. </p>
+        <p class="sig">annotated source: Excerpt from the document abstract</p>
+      </div>
+    </div>
+
+    <div class="bib-entry">
+      <h2 class="sort-name">Smith</h2>
+      <h3 class="ref-title">“The Standard Generalized Markup Language (SGML) for
+      Humanities Publishing” by Joan M. Smith</h3>
+      <p class="ref-location">
+        <a href="https://academic.oup.com/dsh/article-abstract/2/3/171/931654"
+           >https://academic.oup.com/dsh/article-abstract/2/3/171/931654</a>
+      </p>
+      <div class="annotation">
+        <p>This announcement of the SGML Standard features generic
+        markup. Even the abstract is more about generic markup than
+        about SGML itself. </p>
+        <p class="sig">annotated by: B. T. Usdin</p>
+      </div>
+    </div>
+
+    <div class="bib-entry">
+      <h2 class="sort-name">TEI Consortium </h2>
+      <h3 class="ref-title">TEI: A Gentle Introduction to XML</h3>
+      <p class="ref-location">
+        <a href="http://www.tei-c.org/release/doc/tei-p5-doc/en/html/SG.html"
+           >http://www.tei-c.org/release/doc/tei-p5-doc/en/html/SG.html</a></p>
+        <div class="annotation">
+          <p>An excellent introduction. The section: <a
+          href="http://www.tei-c.org/release/doc/tei-p5-doc/en/html/SG.html#SG111"
+          >Descriptive Markup</a> is a short, clear, description of
+          declarative markup and the rest of the document is an
+          excellent discussion of how XML and declarative markup work
+          together. </p>
+          <p class="sig">annotated by: B. T. Usdin</p>
+        </div>
+    </div>
+
+    <div class="bib-entry">
+      <h2 class="sort-name">Usdin</h2>
+      <h3 class="ref-title">“The semantics of ‘semantic’” by B. Tommie Usdin</h3>
+      <p class="ref-location">
+        <a href="http://www.balisage.net/Proceedings/vol10/html/Usdin01/BalisageVol10-Usdin01.html"
+           >http://www.balisage.net/Proceedings/vol10/html/Usdin01/BalisageVol10-Usdin01.html</a></p>
+        <div class="annotation">
+          <p>Readers interested in generic markup should start reading
+          at the heading “The word ‘semantic’”. From that abstract:
+          There was a time when I knew what the word “semantic” meant.
+          That was a long time ago. Since then many people, on many
+          occasions, in many contexts, have corrected my
+          misunderstanding of the meaning of semantic. Perhaps it
+          means nothing, or everything. Or perhaps I’m simply
+          misinformed.</p>
+          <p class="sig">annotated by: B. T. Usdin</p>
+        </div>
+    </div>
+
+    <div class="bib-entry">
+      <h2 class="sort-name">Usdin</h2>
+      <h3 class="ref-title">“YAMC? Why are we here? Why are we here again?” by B. Tommie Usdin</h3>
+      <p class="ref-location">
+        Usdin, B. Tommie. "YAMC? Why are we here? Why are we here
+        again?" Presented at Balisage: The Markup Conference 2018,
+        Washington, DC, July 31 - August 3, 2018. In Proceedings of
+        Balisage: The Markup Conference 2018. Balisage Series on
+        Markup Technologies, vol. 21 (2018).
+        <a href="https://www.balisage.net/Proceedings/vol21/html/Usdin02/BalisageVol21-Usdin02.html">https://doi.org/10.4242/BalisageVol21.Usdin02.</a>
+      </p>
+      <div class="annotation">
+        <p>Transcript of a talk. Readers interested in declarative markup may want
+        to skip the first few paragraphs which are about the conference rather
+        than markup. </p>
+        <p class="sig">annotated by: B. T. Usdin</p>
+      </div>
+    </div>
+
+    <div class="bib-entry">
+      <h2 class="sort-name">Watson</h2>
+      <h3 class="ref-title">“Brief History of Document Markup” by Dennis G. Watson</h3>
+      <p class="ref-location">
+        <a href="http://chnm.gmu.edu/digitalhistory/links/pdf/chapter3/3.19a.pdf"
+           >http://chnm.gmu.edu/digitalhistory/links/pdf/chapter3/3.19a.pdf</a></p>
+        <div class="annotation">
+          <p>This short document includes a very clear description of generic markup. </p>
+          <p class="sig">annotated by: B. T. Usdin</p>
+        </div>
+    </div>
+
+    <div class="bib-entry">
+      <h2 class="sort-name">Webster</h2>
+      <h3 class="ref-title">Short definition in Webster online</h3>
+      <p class="ref-location">
+        <a href="http://www.webster-dictionary.org/definition/generic%20markup"
+           >http://www.webster-dictionary.org/definition/generic%20markup</a>
+      </p>
+      <div class="annotation">
+        <p>Webster’s Dictionary online almost has it. The reference to
+        SGML is confusing a specific syntax that can, but is not
+        necessarily generic markup with the main principle of generic
+        or declarative markup. </p>
+        <p class="sig">annotated by: B. T. Usdin</p>
+      </div>
+    </div>
+  </section>
+
+  <section id="markupuses">
+    <h1>Declarative Markup Uses</h1>
+    <p>Documents about languages that are declarative, uses of
+    declarative markup, and othe topics that are germain to a
+    discussion of declarative markup but are not primarily about
+    declarative markup as a concept</p>
+
+
+    <div class="bib-entry">
+      <h2 class="sort-name">Applen</h2>
+      <h3 class="ref-title">“The Rhetorical Nature of XML: Constructing Knowledge in Networked Environments” by Applen &amp; McDaniel</h3>
+      <p class="ref-location"> Applen, J., McDaniel, R. (2009). The Rhetorical Nature
+      of XML. New York: Routledge. </p>
+      <div class="annotation">
+        <p>Simultaneously the best and the worst book on XML i've ever
+        read (with apologies to the authors if they are reading this)
+        - the technical misunderstandings about XML are deep (e.g.,
+        no, + doesn't mean it's optional in a DTD). This book is
+        recommended highly for its perspectives but be warned that the
+        more technical parts contain a lot of mistakes; Chapters 1, 3,
+        and 7 are particularly helpful.</p>
+        <p class="sig">annotated by: Liam Quin</p>
+      </div>
+    </div>
+
+    <div class="bib-entry">
+      <h2 class="sort-name">Baker</h2>
+      <h3 class="ref-title">“Structured Writing: Rhetoric and Process” by Mark Baker</h3>
+      <p class="ref-location">
+      <a href="">link</a> and/or full bibliographic citation </p>
+      <div class="annotation">
+        <p>“Baker explains what structured writing is and how you can
+        use different structures to achieve different purposes. The
+        book focuses on how you can partition and manage the
+        complexity of the content creation process using structured
+        writing techniques to ensure that everything is handled by the
+        person or process with the skills, time, and resources to
+        handle it effectively.”</p>
+        <p class="sig">annotation source: Description of the book by Richard Hamilton at <a
+                                href="http://xmlpress.net/2018/09/11/structured-writing-rhetoric-and-process/"
+                                >http://xmlpress.net/2018/09/11/structured-writing-rhetoric-and-process/</a></p>
+      </div>
+    </div>
+
+    <div class="bib-entry">
+      <h2 class="sort-name">Lie</h2>
+      <h3 class="ref-title">“Cascading Style Sheets” by Håkon Wium Lie </h3>
+      <p class="ref-location">
+        <a href="http://www.wiumlie.no/2006/phd/css.pdf"
+           >http://www.wiumlie.no/2006/phd/
+        http://www.wiumlie.no/2006/phd/css.pdf</a> Thesis submitted for the
+        degree of Doctor Philosophiœ Faculty of Mathematics and Natural Sciences
+        University of Oslo Norway 2005
+      </p>
+      <div class="annotation">
+        <p>From the Overview:</p>
+        <blockquote>
+          <h2>Chapter 2: Structured documents</h2>
+          <p>Style sheet languages and structured documents are mutually
+              dependent. Without style sheets, structured documents cannot be
+              presented, and without structured documents there is nothing for
+              style sheets to present. Chapter 2 starts by introducing the ladder
+              of abstraction which is proposed as a measuring tool for structured
+              document formats. Such formats developed prior to the web (Scribe,
+              LaTeX, ODA, SGML) and for the web (HTML, XML) are described.
+              Finally, the role of transformation languages vs. style sheet
+              languages is discussed.</p>
+          <h2>Chapter 3: Style sheets prior to the web</h2>
+          <p>Chapter 3 is the first chapter in which style sheets are discussed in
+              some detail. The first part of the chapter establishes a set of
+              criteria for style sheet languages; in order to qualify as a style
+              sheet language six components must be present: syntax, selectors,
+              properties, values and units, value propagation and a formatting
+              model. Three style sheet languages developed before the Web (FOSI,
+              DSSSL and P94) are described. The historical background of each is
+              followed by a technical review.</p>
+          <h2>Chapter 4: Style sheet proposals for the web</h2>
+          <p>This chapter is a survey of the style sheet languages that were
+              proposed for the web in the period 1993-1996. Nine different
+              proposals are reviewed according to the criteria established in the
+              previous chapter.</p>
+        </blockquote>
+
+        <p>Obviously, the rest of the thesis would be of particular interest to a
+        reader interested in the declarative markup known as CSS.</p>
+
+        <p>Its glossary definition of 'declarative language' may also be of
+        interest:</p>
+        
+        <blockquote>
+          <h2>declarative language</h2>
+          <p>A declarative language is a general term for languages
+          which express relationships between variables, as opposed to
+          imperative languages which specify explicit sequences of
+          steps to be followed, in order to produce a result. Often,
+          declarative languages are not Turing-complete, while
+          imperative languages are. All style sheet languages
+          described in this thesis are declarative.</p>
+        </blockquote>
+        <p class="sig">annotated by: Tony Graham </p>
+      </div>
+    </div>
+
+    <div class="bib-entry">
+      <h2 class="sort-name">Quin</h2>
+      <h3 class="ref-title">“THE WORLD WIDE SUCCESS THAT IS XML” by Liam Quin</h3>
+      <p class="ref-location">
+        <a href="https://www.w3.org/blog/2018/07/the-world-wide-success-that-is-xml/"
+           >https://www.w3.org/blog/2018/07/the-world-wide-success-that-is-xml/</a>
+        and/or full bibliographic citation
+      </p>
+      <div class="annotation">
+        <p>Most of the XML Working Groups have been closed by now;
+        this year saw XQuery and XSLT close, their work successfully
+        completed.</p><p>As we wind down work on standardizing the XML
+        stack at W3C it’s worth looking at some of what we have
+        accomplished and why. W3C XML, the Extensible Markup Language,
+        is one of the world’s most widely-used formats for
+        representing and exchanging information. The final XML stack
+        is more powerful and easier to work with than many people
+        know, especially for people who might not have used XML since
+        its early days.</p>
+        <p class="sig">annotated source: excerpt from the document</p>
+      </div>
+    </div>
+  </section>
+
+  <section id="related">
+    <h1>Related Concepts</h1>
+    <p>This section is empty at this time.</p>
+  </section>
+
+</body>
+</html>


### PR DESCRIPTION
This pull request does a few things to integrate Tommie's annotated bibliography
* I added a new "Resources" link to the footer and a corresponding resources page
* I added a link to the bibliography at /resources/bibliography
* I made a few small editorial changes to the bibliography:
  * I took out the system doctype decl
  * I updated the markup to more modern HTML5
  * I added a ToC
  * I fixed a bunch of curly quotes
  * I replaced named character references with proper Unicode characters
  * I tweaked the links in a couple of places.
* I fiddled a bit with some of the layout and include files. This is just housekeeping for the publication system

Hopefully all of those are seen as friendly ammendments.

There's no way to see exactly what the results will be unless you're prepared to pull the changes down locally and run Jekyll yourself. ☹️ I'll see about fixing that when I have time.
