### PR TITLE
A list of upcoming conferences

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -39,7 +39,8 @@ preservation of information or that have open data policies –
 have as much need as ever for declarative markup.
 
 We need a central space in which to discuss, work on, and work with
-these technologies.
+these technologies. For other places to discuss markup, see our new
+[list of events](/resources/events.html)!
 
 Markup Declaration is a community espousing a philosophy of markup
 that enables platform and system independence. The community will

--- a/src/resources/conferences.md
+++ b/src/resources/conferences.md
@@ -1,0 +1,41 @@
+# Upcoming conferences
+
+Got something related to markup on your calendar: conference, workshop, meetup? Tell us about it!
+
+## June, 2019
+
+* [MarkupUK](https://markupuk.org/): 7–9 June, London, GB. A
+  conference about XML and other markup technologies
+
+### July, 2019
+
+* [ACL 2019](http://www.acl2019.org/EN/): 28 July–2 August, Florence,
+  IT. ACL is the premier conference of the field of computational
+  linguistics, covering a broad spectrum of diverse research areas
+  that are concerned with computational approaches to natural
+  language.
+
+* [Balisage](https://www.balisage.net/): 29 July–2 August, Rockville,
+  MD, US. Balisage is an annual conference devoted to the theory and
+  practice of descriptive markup and related technologies for
+  structuring and managing information.
+
+### September, 2019
+
+* [CMC-Corpora](https://www.u-cergy.fr/fr/laboratoires/idhn/actualites/cmc-corpora-conference-2019.html):
+  9–10 September, Cergy-Pontoise, FR. CMC corpora is an annual
+  conference series dedicated to the collection, annotation,
+  processing and exploitation of corpora of computer-mediated
+  communication (CMC) and social media for research in the humanities.
+
+* [XML Summer School](https://xmlsummerschool.com/): 15–20 September,
+  Oxford, GB. The XML Summer School is for everyone using, designing,
+  or implementing solutions using XML and related technologies. The
+  week-long event is made up of courses which range from the basics of
+  XML to advanced topics in linked data, web design, and publishing.
+
+* [Text Encoding Initiative](https://graz-2019.tei-c.org/): 16–20
+  September, Graz, AT. The TEI's annual conference and members'
+  meeting is the gathering point for the TEI community. It offers an
+  opportunity to meet with colleagues, learn about new projects, share
+  research, and find out about new developments in the TEI.

--- a/src/resources/events.md
+++ b/src/resources/events.md
@@ -1,6 +1,7 @@
 # Upcoming conferences
 
-Got something related to markup on your calendar: conference, workshop, meetup? Tell us about it!
+Got something related to markup on your calendar: conference, workshop, meetup?
+[Tell us about it](/contact.html)!
 
 ## May, 2019
 

--- a/src/resources/events.md
+++ b/src/resources/events.md
@@ -2,12 +2,26 @@
 
 Got something related to markup on your calendar: conference, workshop, meetup? Tell us about it!
 
+## May, 2019
+
+* [JATS-Con](https://www.eventsforce.net/wgcconferencecentre/frontend/reg/thome.csp?pageID=5088&eventID=17&traceRedir=2):
+  20–21 May, Cambridge, GB. The conference on the use of the Journal
+  Article Tag Suite (JATS) in publishing workflows. This year, the
+  theme of JATS-Con will be the changing face of journal publishing.
+
 ## June, 2019
 
 * [MarkupUK](https://markupuk.org/): 7–9 June, London, GB. A
   conference about XML and other markup technologies
 
 ### July, 2019
+
+* [Digital Humanities at Oxford Summer
+  School](http://www.oerc.ox.ac.uk/dhoxss-2019): 22–26 July, Oxford,
+  GB. DHOxSS offers a range of training workshops to anyone with an
+  interest in the Digital Humanities, including academics at all
+  career stages, students, project managers, and people who work in
+  IT, libraries, and cultural heritage.
 
 * [ACL 2019](http://www.acl2019.org/EN/): 28 July–2 August, Florence,
   IT. ACL is the premier conference of the field of computational

--- a/src/resources/index.md
+++ b/src/resources/index.md
@@ -1,4 +1,4 @@
 # Resources
 
 * An [annotated bibliography](/resources/bibliography.html)
-
+* A list of [upcoming conferences](/resources/conferences.html) related to markup

--- a/src/resources/index.md
+++ b/src/resources/index.md
@@ -1,4 +1,4 @@
 # Resources
 
 * An [annotated bibliography](/resources/bibliography.html)
-* A list of [upcoming conferences](/resources/conferences.html) related to markup
+* A list of [upcoming events](/resources/events.html) related to markup


### PR DESCRIPTION
This idea came up in a conversation recently. I decided to put together a skeleton to "run it up the flagpole".

1. I'd be interested in a comprehensive list of (broadly) markup-related upcoming conferences
2. If there are already such lists in existence, I don't know if we want to duplicate them
3. Such a list requires maintenance, which I'm committing to for at least some period of time, assuming we think this is worth doing at all.
