### PR TITLE
Updates to the events page

### DIFF
--- a/src/resources/event-history.html
+++ b/src/resources/event-history.html
@@ -14,6 +14,162 @@
 markup-related events. A record of past events is recorded on this page.
 </p>
 
+
+<div class="month" id="x2019-09">
+<h2>September, 2019</h2>
+
+<ul>
+<li typeof="DataFeedItem" property="dateCreated" content="2019—04-13">
+<p id="cmc-corpora" typeof="Event">
+<span property="name">
+<a property="url" href="https://www.u-cergy.fr/fr/laboratoires/idhn/actualites/cmc-corpora-conference-2019.html">CMC-Corpora</a></span>:
+<span property="startDate" content="2019-09-09">9</span>–<span property="endDate" content="2019-09-10">10</span> September,
+<span property="location">Cergy-Pontoise, FR</span>.
+<span property="description">CMC corpora is an annual conference
+series dedicated to the collection, annotation, processing and
+exploitation of corpora of computer-mediated communication (CMC) and
+social media for research in the humanities.</span></p>
+</li>
+
+<li typeof="DataFeedItem" property="dateCreated" content="2019—06-04">
+<p id="tei" typeof="Event">
+<span property="name"><a property="url" href="https://informationsmodellierung.uni-graz.at/de/veranstaltungen/tei-introductory-school-september-2019/">TEI Introductory School</a></span>:
+<span property="startDate" content="2019-09-10">10</span>–<span property="endDate" content="2019-09-13">13</span> September,
+<span property="location">Graz, AT</span>.
+<span property="description">The summer school is directed to
+participants with no or limited previous experience in digital
+scholarly editing and modelling texts using XML/TEI. In this summer
+school participants will learn the fundamental rules of XML/TEI, how
+they can use this markup language to model different kinds of texts
+and the fundamental of the workflow from text encoding to the
+publication on the WWW. This will be a hands-on summer school and
+participants will gain skills in writing XML/TEI and navigating it
+using the XPath language. </span></p>
+</li>
+
+<li typeof="DataFeedItem" property="dateCreated" content="2019—04-13">
+<p id="xml-summer-school" typeof="Event">
+<span property="name"><a property="url" href="https://xmlsummerschool.com/">XML Summer School</a></span>:
+<span property="startDate" content="2019-09-15">15</span>–<span property="endDate" content="2019-09-20">20</span> September,
+<span property="location">Oxford, GB</span>.
+<span property="description">The XML Summer School is for everyone
+using, designing, or implementing solutions using XML and related
+technologies. The week-long event is made up of courses which range
+from the basics of XML to advanced topics in linked data, web design,
+and publishing.</span></p>
+</li>
+
+<li typeof="DataFeedItem" property="dateCreated" content="2019—04-13">
+<p id="tei" typeof="Event">
+<span property="name"><a property="url" href="https://graz-2019.tei-c.org/">Text Encoding Initiative</a></span>:
+<span property="startDate" content="2019-09-16">16</span>–<span property="endDate" content="2019-09-20">20</span> September,
+<span property="location">Graz, AT</span>.
+<span property="description">The TEI's annual conference and members'
+meeting is the gathering point for the TEI community. It offers an
+opportunity to meet with colleagues, learn about new projects, share
+research, and find out about new developments in the TEI.</span></p>
+</li>
+<li typeof="DataFeedItem" property="dateCreated" content="2019—04-16">
+<p id="doceng-2019" typeof="Event">
+<span property="name"><a property="url" href="https://doceng.org/doceng2019/index">DocEng 2019</a></span>:
+<span property="startDate" content="2019-09-23">23</span>–<span property="endDate" content="2019-09-26">26</span> September,
+<span property="location">Berlin, DE</span>.
+<span property="description">The 19th ACM Symposium on Document
+Engineering seeks original research papers that focus on the design,
+implementation, development, management, use and evaluation of
+advanced systems where document and document collections play a key
+role. DocEng emphasizes innovative approaches to document engineering
+technology, use of documents and document collections in real-world
+applications, novel principles, tools and processes that improve our
+ability to create, manage, maintain, share, and productively use
+these. In particular, DocEng 2019 seeks contributions involving in the
+area of cooperative work with documents.</span></p>
+</li>
+</ul>
+</div>
+
+
+<div class="month" id="x2019-07">
+<h2>July, 2019</h2>
+
+<ul>
+<li typeof="DataFeedItem" property="dateCreated" content="2019-04-13">
+<p id="dhoxss" typeof="Event">
+<span property="name"><a property="url"
+href="http://www.oerc.ox.ac.uk/dhoxss-2019">Digital Humanities at
+Oxford Summer School</a></span>:
+<span property="startDate" content="2019-07-22">22</span>–<span property="endDate" content="2019-07-26">26</span> July,
+<span property="location">Oxford, GB</span>.
+<span property="description">DHOxSS offers a range of training
+workshops to anyone with an interest in the Digital Humanities,
+including academics at all career stages, students, project managers,
+and people who work in IT, libraries, and cultural
+heritage.</span></p>
+</li>
+<li typeof="DataFeedItem" property="dateCreated" content="2019-04-16">
+<p id="informanagementcenter" typeof="Event">
+<span property="name"><a property="url" href="https://ideas.infomanagementcenter.com/">The
+Many Hats of a Technical Communicator</a></span>:
+<span property="startDate" content="2019-07-23">23</span>–<span property="endDate" content="2019-07-24">24</span> July,
+Online.
+<span property="description">The technical communication field
+continues to evolve rapidly and those who work in it are faced with a
+growing list of responsibilities that they must be prepared to handle.
+The 2019 Summer IDEAS online conference will offer a comprehensive
+cross section of what the technical communication discipline has
+become and is becoming.</span></p>
+</li>
+<li typeof="DataFeedItem" property="dateCreated" content="2019-04-13">
+<p id="ach2019" typeof="Event">
+<span property="name"><a property="url" href="http://ach2019.ach.org/">ACH 2019</a></span>:
+<span property="startDate" content="2019-07-23">23</span>–<span property="endDate" content="2019-07-26">26</span> July,
+<span property="location">Pittsburg, PA, US</span>.
+<span property="description">ACH is the United States-based
+constituent organization in the Alliance for Digital Humanities
+Organizations (ADHO). The ACH2019 conference, in partnership with
+Keystone DH, provides a forum for conversations on an expansive
+definition of digital humanities in a broad array of subject areas,
+methods, and communities of practice.</span></p>
+</li>
+
+<li typeof="DataFeedItem" property="dateCreated" content="2019-04-21">
+<p id="mandigital" typeof="Event">
+<span property="name"><a property="url"
+href="http://www.culingtec.uni-leipzig.de/ESU_C_T/node/1133">Manuscripts
+in the Digital Age: XML-Based Catalogues and Editions</a></span>:
+<span property="startDate" content="2019-07-23">23 July</span>–<span property="endDate" content="2019-08-02">2 August</span>,
+<span property="location">Leipzig, DE</span>.
+<span property="description">This course provides a hands-on approach
+to working with medieval and early modern manuscripts in the digital
+context. The course consists of two main aspects: (1) creating
+XML-based manuscript descriptions and (2) preparing XML-based editions
+of texts, with or without an apparatus criticus, according to the
+Guidelines of the Text Encoding Initiative (TEI).
+</span></p>
+</li>
+
+<li typeof="DataFeedItem" property="dateCreated" content="2019-04-13">
+<p id="acl2019" typeof="Event">
+<span property="name"><a property="url" href="http://www.acl2019.org/EN/">ACL 2019</a></span>:
+<span property="startDate" content="2019-07-28">28 July</span>–<span property="endDate" content="2019-08-02">2 August</span>,
+<span property="location">Florence, IT.</span>.
+<span property="description">ACL is the premier conference of the
+field of computational linguistics, covering a broad spectrum of
+diverse research areas that are concerned with computational
+approaches to natural language.</span></p>
+</li>
+<li typeof="DataFeedItem" property="dateCreated" content="2019-04-13">
+<p id="balisage" typeof="Event">
+<span property="name"><a property="url" href="https://www.balisage.net/">Balisage 2019</a></span>:
+<span property="startDate" content="2019-07-29">29 July</span>–<span property="endDate" content="2019-08-02">2 August</span>,
+<span property="location">Rockville, MD, US</span>.
+<span property="description">Balisage is an annual conference devoted
+to the theory and practice of descriptive markup and related
+technologies for structuring and managing information.</span></p>
+</li>
+</ul>
+</div>
+
 <div class="month" id="x2019-06">
 <h2>June, 2019</h2>
 

--- a/src/resources/events.html
+++ b/src/resources/events.html
@@ -17,160 +17,6 @@ about that as well. (Past event listings are available on the
 <a href="event-history.html">event history</a> page.)
 </p>
 
-<div class="month" id="x2019-07">
-<h2>July, 2019</h2>
-
-<ul>
-<li typeof="DataFeedItem" property="dateCreated" content="2019-04-13">
-<p id="dhoxss" typeof="Event">
-<span property="name"><a property="url"
-href="http://www.oerc.ox.ac.uk/dhoxss-2019">Digital Humanities at
-Oxford Summer School</a></span>:
-<span property="startDate" content="2019-07-22">22</span>–<span property="endDate" content="2019-07-26">26</span> July,
-<span property="location">Oxford, GB</span>.
-<span property="description">DHOxSS offers a range of training
-workshops to anyone with an interest in the Digital Humanities,
-including academics at all career stages, students, project managers,
-and people who work in IT, libraries, and cultural
-heritage.</span></p>
-</li>
-<li typeof="DataFeedItem" property="dateCreated" content="2019-04-16">
-<p id="informanagementcenter" typeof="Event">
-<span property="name"><a property="url" href="https://ideas.infomanagementcenter.com/">The
-Many Hats of a Technical Communicator</a></span>:
-<span property="startDate" content="2019-07-23">23</span>–<span property="endDate" content="2019-07-24">24</span> July,
-Online.
-<span property="description">The technical communication field
-continues to evolve rapidly and those who work in it are faced with a
-growing list of responsibilities that they must be prepared to handle.
-The 2019 Summer IDEAS online conference will offer a comprehensive
-cross section of what the technical communication discipline has
-become and is becoming.</span></p>
-</li>
-<li typeof="DataFeedItem" property="dateCreated" content="2019-04-13">
-<p id="ach2019" typeof="Event">
-<span property="name"><a property="url" href="http://ach2019.ach.org/">ACH 2019</a></span>:
-<span property="startDate" content="2019-07-23">23</span>–<span property="endDate" content="2019-07-26">26</span> July,
-<span property="location">Pittsburg, PA, US</span>.
-<span property="description">ACH is the United States-based
-constituent organization in the Alliance for Digital Humanities
-Organizations (ADHO). The ACH2019 conference, in partnership with
-Keystone DH, provides a forum for conversations on an expansive
-definition of digital humanities in a broad array of subject areas,
-methods, and communities of practice.</span></p>
-</li>
-
-<li typeof="DataFeedItem" property="dateCreated" content="2019-04-21">
-<p id="mandigital" typeof="Event">
-<span property="name"><a property="url"
-href="http://www.culingtec.uni-leipzig.de/ESU_C_T/node/1133">Manuscripts
-in the Digital Age: XML-Based Catalogues and Editions</a></span>:
-<span property="startDate" content="2019-07-23">23 July</span>–<span property="endDate" content="2019-08-02">2 August</span>,
-<span property="location">Leipzig, DE</span>.
-<span property="description">This course provides a hands-on approach
-to working with medieval and early modern manuscripts in the digital
-context. The course consists of two main aspects: (1) creating
-XML-based manuscript descriptions and (2) preparing XML-based editions
-of texts, with or without an apparatus criticus, according to the
-Guidelines of the Text Encoding Initiative (TEI).
-</span></p>
-</li>
-
-<li typeof="DataFeedItem" property="dateCreated" content="2019-04-13">
-<p id="acl2019" typeof="Event">
-<span property="name"><a property="url" href="http://www.acl2019.org/EN/">ACL 2019</a></span>:
-<span property="startDate" content="2019-07-28">28 July</span>–<span property="endDate" content="2019-08-02">2 August</span>,
-<span property="location">Florence, IT.</span>.
-<span property="description">ACL is the premier conference of the
-field of computational linguistics, covering a broad spectrum of
-diverse research areas that are concerned with computational
-approaches to natural language.</span></p>
-</li>
-<li typeof="DataFeedItem" property="dateCreated" content="2019-04-13">
-<p id="balisage" typeof="Event">
-<span property="name"><a property="url" href="https://www.balisage.net/">Balisage 2019</a></span>:
-<span property="startDate" content="2019-07-29">29 July</span>–<span property="endDate" content="2019-08-02">2 August</span>,
-<span property="location">Rockville, MD, US</span>.
-<span property="description">Balisage is an annual conference devoted
-to the theory and practice of descriptive markup and related
-technologies for structuring and managing information.</span></p>
-</li>
-</ul>
-</div>
-
-<div class="month" id="x2019-09">
-<h2>September, 2019</h2>
-
-<ul>
-<li typeof="DataFeedItem" property="dateCreated" content="2019—04-13">
-<p id="cmc-corpora" typeof="Event">
-<span property="name">
-<a property="url" href="https://www.u-cergy.fr/fr/laboratoires/idhn/actualites/cmc-corpora-conference-2019.html">CMC-Corpora</a></span>:
-<span property="startDate" content="2019-09-09">9</span>–<span property="endDate" content="2019-09-10">10</span> September,
-<span property="location">Cergy-Pontoise, FR</span>.
-<span property="description">CMC corpora is an annual conference
-series dedicated to the collection, annotation, processing and
-exploitation of corpora of computer-mediated communication (CMC) and
-social media for research in the humanities.</span></p>
-</li>
-
-<li typeof="DataFeedItem" property="dateCreated" content="2019—06-04">
-<p id="tei" typeof="Event">
-<span property="name"><a property="url" href="https://informationsmodellierung.uni-graz.at/de/veranstaltungen/tei-introductory-school-september-2019/">TEI Introductory School</a></span>:
-<span property="startDate" content="2019-09-10">10</span>–<span property="endDate" content="2019-09-13">13</span> September,
-<span property="location">Graz, AT</span>.
-<span property="description">The summer school is directed to
-participants with no or limited previous experience in digital
-scholarly editing and modelling texts using XML/TEI. In this summer
-school participants will learn the fundamental rules of XML/TEI, how
-they can use this markup language to model different kinds of texts
-and the fundamental of the workflow from text encoding to the
-publication on the WWW. This will be a hands-on summer school and
-participants will gain skills in writing XML/TEI and navigating it
-using the XPath language. </span></p>
-</li>
-
-<li typeof="DataFeedItem" property="dateCreated" content="2019—04-13">
-<p id="xml-summer-school" typeof="Event">
-<span property="name"><a property="url" href="https://xmlsummerschool.com/">XML Summer School</a></span>:
-<span property="startDate" content="2019-09-15">15</span>–<span property="endDate" content="2019-09-20">20</span> September,
-<span property="location">Oxford, GB</span>.
-<span property="description">The XML Summer School is for everyone
-using, designing, or implementing solutions using XML and related
-technologies. The week-long event is made up of courses which range
-from the basics of XML to advanced topics in linked data, web design,
-and publishing.</span></p>
-</li>
-
-<li typeof="DataFeedItem" property="dateCreated" content="2019—04-13">
-<p id="tei" typeof="Event">
-<span property="name"><a property="url" href="https://graz-2019.tei-c.org/">Text Encoding Initiative</a></span>:
-<span property="startDate" content="2019-09-16">16</span>–<span property="endDate" content="2019-09-20">20</span> September,
-<span property="location">Graz, AT</span>.
-<span property="description">The TEI's annual conference and members'
-meeting is the gathering point for the TEI community. It offers an
-opportunity to meet with colleagues, learn about new projects, share
-research, and find out about new developments in the TEI.</span></p>
-</li>
-<li typeof="DataFeedItem" property="dateCreated" content="2019—04-16">
-<p id="doceng-2019" typeof="Event">
-<span property="name"><a property="url" href="https://doceng.org/doceng2019/index">DocEng 2019</a></span>:
-<span property="startDate" content="2019-09-23">23</span>–<span property="endDate" content="2019-09-26">26</span> September,
-<span property="location">Berlin, DE</span>.
-<span property="description">The 19th ACM Symposium on Document
-Engineering seeks original research papers that focus on the design,
-implementation, development, management, use and evaluation of
-advanced systems where document and document collections play a key
-role. DocEng emphasizes innovative approaches to document engineering
-technology, use of documents and document collections in real-world
-applications, novel principles, tools and processes that improve our
-ability to create, manage, maintain, share, and productively use
-these. In particular, DocEng 2019 seeks contributions involving in the
-area of cooperative work with documents.</span></p>
-</li>
-</ul>
-</div>
-
 <div class="month" id="x2019-11">
 <h2>November, 2019</h2>
 
@@ -189,6 +35,92 @@ The event is organized by Simona Olivieri, Humboldt Research Fellow -
 Seminar für Semitistik und Arabistik, Freie Universität Berlin, with
 the support of the Alexander von Humboldt Foundation.
 </span></p>
+</li>
+</ul>
+</div>
+
+<div class="month" id="x2020-06">
+<h2>June, 2020</h2>
+<ul>
+<li typeof="DataFeedItem" property="dateCreated" content="2019-10-02">
+<p id="markupuk2020" typeof="Event">
+<span property="name"><a property="url" href="https://markupuk.org/">MarkupUK</a></span>:
+<span property="startDate" content="2020-06-04">4</span>–<span property="endDate" content="2020-06-06">6</span> June,
+<span property="location">King’s College, London, GB</span>.
+<span property="description">A conference about XML and other markup
+technologies.</span></p>
+</li>
+<li typeof="DataFeedItem" property="dateCreated" content="2019-10-02">
+<p id="dhc2020" typeof="Event">
+<span property="name"><a property="url" href="https://www.expohour.com/digital-humanities-conferences">The
+Digital Humanities Conference</a></span>:
+<span property="startDate" content="2020-06-24">24 June</span>–<span property="endDate" content="2020-07-01">1 July</span>,
+<span property="location">London, GB</span>.
+<span property="description">The Digital Humanities Conference is going to be organised at UCL
+Centre for Digital Humanities, London, UK from 24 Jun 2020 to 01 Jul
+2020 This expo is going to be a 8 day event. This event forays into
+categories like Information Technology. </span></p>
+</li>
+</ul>
+</div>
+
+<div class="month" id="x2020-07">
+<h2>July, 2020</h2>
+<ul>
+<li typeof="DataFeedItem" property="dateCreated" content="2019-10-02">
+<p id="acl2020" typeof="Event">
+<span property="name"><a property="url" href="http://www.acl2020.org/EN/">ACL 2020</a></span>:
+<span property="startDate" content="2020-07-05">5</span>–<span property="endDate" content="2020-07-10">10 July</span>,
+<span property="location">Seattle, WA, US.</span>.
+<span property="description">ACL is the premier conference of the
+field of computational linguistics, covering a broad spectrum of
+diverse research areas that are concerned with computational
+approaches to natural language.</span></p>
+</li>
+<li typeof="DataFeedItem" property="dateCreated" content="2019-10-03">
+<p id="dhoxss2020" typeof="Event">
+<span property="name"><a property="url"
+href="https://www.eng.ox.ac.uk/events/digital-humanities-at-oxford-summer-school-2020/">Digital Humanities at
+Oxford Summer School</a></span>:
+<span property="startDate" content="2020-07-13">13</span>–<span property="endDate" content="2020-07-17">17</span> July,
+<span property="location">Keble College, Oxford, GB</span>.
+<span property="description">DHOxSS offers a range of training workshops to anyone with an interest
+in the Digital Humanities, including academics at all career stages,
+students, project managers, and people who work in IT, libraries,
+archives, and cultural heritage.
+</span></p>
+</li>
+<li typeof="DataFeedItem" property="dateCreated" content="2019-10-02">
+<p id="balisage2020" typeof="Event">
+<span property="name"><a property="url" href="https://www.balisage.net/">Balisage</a></span>:
+<span property="startDate" content="2020-07-28">28</span>–<span property="endDate" content="2020-07-31">31 July</span>,
+<span property="location">Rockville, MD, US</span>.
+<span property="description">Balisage is an annual conference devoted
+to the theory and practice of descriptive markup and related
+technologies for structuring and managing information.</span></p>
+</li>
+</ul>
+</div>
+
+<div class="month" id="x2020-09">
+<h2>September, 2020</h2>
+<ul>
+<li typeof="DataFeedItem" property="dateCreated" content="2019—10-03">
+<p id="doceng-2020" typeof="Event">
+<span property="name"><a property="url" href="https://doceng.org/doceng2020/index">The 20th ACM Symposium on Document Engineering</a></span>
+<span property="startDate" content="2020-09-20">20 September</span>–<span property="endDate" content="2020-10-02">2</span> October,
+<span property="location">San Jose, CA, US</span>.
+<span property="description">The 20th ACM Symposium on Document
+Engineering (DocEng 2020) seeks original research papers that focus on
+the design, implementation, development, management, use and
+evaluation of advanced systems where documents and document
+collections play a key role. DocEng emphasizes innovative approaches
+to document engineering technology, use of documents and document
+collections in real-world applications, and novel principles, tools
+and processes that improve our ability to create, manage, maintain,
+share, and productively use these. In particular, DocEng 2020 seeks
+contributions in the area of cooperative work with documents.</span>
+</p>
 </li>
 </ul>
 </div>

--- a/src/resources/events.html
+++ b/src/resources/events.html
@@ -91,6 +91,19 @@ archives, and cultural heritage.
 </span></p>
 </li>
 <li typeof="DataFeedItem" property="dateCreated" content="2019-10-02">
+<p id="balisagesympoium2020" typeof="Event">
+<span property="name"><a property="url" href="https://www.balisage.net/Accessibility/">The Role of XML in Publishing Accessible Documents</a></span>:
+<span property="startDate" content="2020-07-27">27 July</span>,
+<span property="location">Rockville, MD, US</span>.
+<span property="description">In this one-day symposium we will explore
+the role of XML in supporting accessibility. There is a moral as well
+as a legal imperative to make information and documents more
+accessible. What can we, the XML community, do to enable the creation
+and publication of accessible documents? What can we learn from the
+Accessibility community?
+</span></p>
+</li>
+<li typeof="DataFeedItem" property="dateCreated" content="2019-10-02">
 <p id="balisage2020" typeof="Event">
 <span property="name"><a property="url" href="https://www.balisage.net/">Balisage</a></span>:
 <span property="startDate" content="2020-07-28">28</span>–<span property="endDate" content="2020-07-31">31 July</span>,


### PR DESCRIPTION
Moved past events to the history page; repopulated the events page with the easy-to-find 2020 events.
